### PR TITLE
Feature/preprocessing columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ A simple, extensible CLI for downloading the Human Phenotype Ontology, parsing g
 3. [Installation](#installation)  
 4. [Quickstart](#quickstart)  
    - [Download HPO JSON](#download-hpo-json)  
-   - [Parse Excel to Phenopackets](#parse-excel-to-phenopackets)  
+   - [Parse Excel to Phenopackets](#parse-excel-to-phenopackets)
+   - [Audit Excel Workbooks](#audit-excel-workbooks)
 5. [CLI Reference](#cli-reference)  
    - [`p6 download`](#p6-download)  
    - [`p6 parse-excel`](#p6-parse-excel)  
+   - [`p6 audit-excel`](#p6-audit-excel)
 6. [Development & Testing](#development--testing)  
 7. [Contributing](#contributing)  
 8. [License](#license)  
@@ -94,6 +96,18 @@ Resulting phenopacket files will be under:
 phenopacket_from_excel/$(date "+%Y-%m-%d_%H-%M-%S")/phenopackets/
 ```
 
+### Audit Excel Workbooks
+
+Quickly check each sheet in an Excel file for header normalization, sheet classification, and presence of required variant columns.
+```bash
+p6 audit-excel -e tests/data/Sydney_Python_transformation.xlsx
+```
+
+By default you get a table; use `-r` for a JSON output to the console.
+```bash
+p6 audit-excel -e tests/data/Sydney_Python_transformation.xlsx -r
+```
+
 ## CLI Reference
 
 ### p6 download
@@ -101,11 +115,13 @@ phenopacket_from_excel/$(date "+%Y-%m-%d_%H-%M-%S")/phenopackets/
 Usage:
 ```markdown
 p6 download [OPTIONS]
+```
 
 Options:
-    -d, --data-path PATH    where to save HPO JSON (default: tests/data)
-    -v, --hpo-version TEXT  exact HPO release tag (e.g. 2025-03-03 or v2025-03-03)
-    --help                  Show this help message and exit.
+```markdown
+    -d, --data-path PATH        where to save HPO JSON (default: tests/data)
+    -v, --hpo-version TEXT      exact HPO release tag (e.g. 2025-03-03 or v2025-03-03)
+    --help                      Show this help message and exit.
 ```
 
 Examples:
@@ -130,9 +146,9 @@ Usage: `p6 parse-excel [OPTIONS] EXCEL_FILE`
 
 Options:
 ```markdown
-    -e, --excel-path FILE    path to the Excel workbook  [required]
-    -hpo, --custom-hpo FILE  path to a custom HPO JSON file (defaults to `tests/data/hp.json`)
-    --help                  Show this message and exit.
+    -e, --excel-path FILE       path to the Excel workbook  [required]
+    -hpo, --custom-hpo FILE     path to a custom HPO JSON file (defaults to `tests/data/hp.json`)
+    --help                      Show this message and exit.
 ```
 
 Example:
@@ -140,6 +156,19 @@ Example:
 Explicitly point at a custom HPO file:
 ```bash
 p6 parse-excel -e tests/data/Sydney_Python_transformation.xlsx -hpo src/P6/hp.json
+```
+
+### p6 audit-excel
+
+Run a lightweight audit on each sheet in an Excel workbook, reporting header counts, sheet classification, and missing variant‐column checks.
+
+Usage: `p6 audit-excel [OPTIONS] EXCEL_FILE`
+
+Options:
+```markdown
+    -e, --excel-path FILE   path to the Excel workbook  [required]
+    -r, --report-json       output audit report as JSON instead of table
+    --help                  Show this message and exit.
 ```
 
 ## Development & Testing

--- a/src/P6/__main__.py
+++ b/src/P6/__main__.py
@@ -121,11 +121,6 @@ def parse_excel(excel_file: str, hpo_path: typing.Optional[str] = None):
     # 5) Report any errors or warnings
     _report_issues(notepad)
 
-    # pps = mapper.apply_mapping(all_sheets, notepad)
-    # assert not notepad.has_errors_or_warnings(include_subsections=True)
-    # TODO: write phenopackets to a folder
-    # click.echo(f"Created {len(pps)} Phenotype objects")
-
     # 6) Group results by patient
     records_by_patient = _group_records_by_patient(genotype_records, phenotype_records)
 

--- a/src/P6/__main__.py
+++ b/src/P6/__main__.py
@@ -234,9 +234,7 @@ def _write_phenopackets(
                 genomic_interpretation_entry.InterpretationStatus.CONTRIBUTORY
             )
 
-            # now fill in the VariationDescriptor
-            # TODO: set this up later
-            # Omit setting gene_context for now.
+            # TODO: Revise VariationDescriptor and gene_context later, omit setting gene_context for now.
             # variation_descriptor = genomic_interpretation_entry.variant_interpretation.variation_descriptor
             # we can also set variation_descriptor.gene_context and variation_descriptor.allelic_state here then serialize out as before
             # variation_descriptor.gene_context.gene_symbol = genotype_record.gene_symbol
@@ -247,13 +245,13 @@ def _write_phenopackets(
             variation_descriptor = variant_interpretation.variation_descriptor
 
             # 1) Gene symbol & allelic state
-            # 'gene_context' is a message; you must CopyFrom if setting a message,
-            # but for its scalar fields you can still assign directly:
+            # 'gene_context' is a message; we need to CopyFrom if setting a message,
+            # but for its scalar fields we can still assign directly:
             variation_descriptor.gene_context.symbol = genotype_record.gene_symbol
             variation_descriptor.allelic_state.CopyFrom(
                 pps2.OntologyClass(
                     id="GENO:"
-                    + genotype_record.zygosity_code,  # or however you construct this
+                    + genotype_record.zygosity_code,  # or however we decide to construct this later on
                     label=genotype_record.zygosity,
                 )
             )
@@ -284,12 +282,6 @@ def _write_phenopackets(
             except AttributeError:
                 # some protobuffs give trouble when trying to expose location/alleles so just skip
                 pass
-
-            # TODO: when ready, add an Expression.HGVS here
-            # Record the HGVS genomic notation as an Expression
-            # expr = variation_descriptor.expressions.add()
-            # expr.syntax = Phenopacket.Diagnosis.GenomicInterpretation.VariantInterpretation.VariationDescriptor.Expression.HGVS
-            # expr.value = genotype_record.hgvsg
 
         # 3d) Serialize to JSON
         generated_phenopacket_output_path = (

--- a/src/P6/__main__.py
+++ b/src/P6/__main__.py
@@ -33,8 +33,21 @@ def main():
 
 
 @main.command(name="audit-excel")
-@click.option("-e", "--excel-path", "excel_file", required=True, type=click.Path(exists=True, dir_okay=False), help="path to the Excel workbook")
-@click.option("-r", "--report-json", "report_json", is_flag=True, help="output audit report as JSON instead of table")
+@click.option(
+    "-e",
+    "--excel-path",
+    "excel_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="path to the Excel workbook",
+)
+@click.option(
+    "-r",
+    "--report-json",
+    "report_json",
+    is_flag=True,
+    help="output audit report as JSON instead of table",
+)
 def audit_excel(excel_file: str, report_json: bool):
     """
     Run a preprocessing audit on each sheet in the given workbook:
@@ -47,6 +60,7 @@ def audit_excel(excel_file: str, report_json: bool):
 
     # 2) Produce audit entries
     from .__main__ import preprocess
+
     entries = preprocess(tables)
 
     # 3) Render report
@@ -55,13 +69,14 @@ def audit_excel(excel_file: str, report_json: bool):
         payload = [
             {"step": e.step, "sheet": e.sheet, "level": e.level, "message": e.message}
             for e in entries
-       ]
+        ]
         click.echo(json.dumps(payload, indent=2))
     else:
         # table header
         click.echo(f"{'SHEET':20}  {'STEP':25}  {'LEVEL':8}  MESSAGE")
         for e in entries:
             click.echo(f"{e.sheet:20}  {e.step:25}  {e.level:8}  {e.message}")
+
 
 @main.command(name="download")
 @click.option(

--- a/src/P6/__main__.py
+++ b/src/P6/__main__.py
@@ -46,7 +46,6 @@ def main():
     help="exact HPO release tag (e.g. 2025-03-03 or v2025-03-03)",
 )
 def download(data_dir: str, hpo_version: typing.Optional[str]):
-    # TODO: download an HPO
     """
     Download a specific or the latest HPO JSON release into the tests/data/ folder.
     """

--- a/src/P6/mapper.py
+++ b/src/P6/mapper.py
@@ -19,14 +19,6 @@ from .genotype import Genotype
 from .phenotype import Phenotype
 
 
-class TableMapper(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def apply_mapping(
-        self, tables: dict[str, pd.DataFrame], notepad: Notepad
-    ) -> typing.Sequence[Phenopacket]:
-        pass
-
-
 # For any renamed field, the two neighbors it must sit between
 EXPECTED_COLUMN_NEIGHBORS = {
     "start_position": ("chromosome", "end_position"),
@@ -71,6 +63,12 @@ INHERITANCE_MAP = {
     "denovo": "de_novo_mutation",
 }
 
+class TableMapper(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def apply_mapping(
+        self, tables: dict[str, pd.DataFrame], notepad: Notepad
+    ) -> typing.Sequence[Phenopacket]:
+        pass
 
 class DefaultMapper(TableMapper):
     def __init__(self, hpo: hpotk.MinimalOntology):

--- a/tests/test_cli_audit_excel.py
+++ b/tests/test_cli_audit_excel.py
@@ -1,0 +1,45 @@
+import glob
+import os
+import pytest
+import re
+from click.testing import CliRunner
+from P6.__main__ import main
+
+@pytest.fixture(scope="session", autouse=True)
+def verify_hpo_file():
+    # ensure HPO file is in place
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
+    assert os.path.isdir(data_dir)
+
+@pytest.mark.parametrize(
+    "sample_xlsx",
+    glob.glob(os.path.join(os.path.dirname(__file__), "data", "*.xlsx")),
+)
+def test_audit_excel_table_output(sample_xlsx):
+    runner = CliRunner()
+    result = runner.invoke(main, ["audit-excel", "-e", sample_xlsx])
+    assert result.exit_code == 0, result.output
+
+    # first line should be our header
+    first = result.output.splitlines()[0]
+    assert first.startswith("SHEET"), "Expected table header"
+    # each subsequent line should have 4 columns
+    for line in result.output.splitlines()[1:]:
+        parts = re.split(r"\s{2,}", line.strip())
+        assert len(parts) >= 4, f"Bad line in audit table: {line}"
+
+def test_audit_excel_json_output(tmp_path):
+    # pick any test workbook
+    sample = glob.glob(os.path.join(os.path.dirname(__file__), "data", "*.xlsx"))[0]
+    runner = CliRunner()
+    result = runner.invoke(main, ["audit-excel", "-e", sample, "-r"])
+    assert result.exit_code == 0, result.output
+
+    # JSON must parse to a list of dicts
+    import json
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert all(isinstance(obj, dict) for obj in payload)
+    # check expected keys
+    for obj in payload:
+        assert {"step","sheet","level","message"}.issubset(obj.keys())

--- a/tests/test_cli_audit_excel.py
+++ b/tests/test_cli_audit_excel.py
@@ -5,15 +5,16 @@ import re
 from click.testing import CliRunner
 from P6.__main__ import main
 
+
 @pytest.fixture(scope="session", autouse=True)
 def verify_hpo_file():
     # ensure HPO file is in place
     data_dir = os.path.join(os.path.dirname(__file__), "data")
     assert os.path.isdir(data_dir)
 
+
 @pytest.mark.parametrize(
-    "sample_xlsx",
-    glob.glob(os.path.join(os.path.dirname(__file__), "data", "*.xlsx")),
+    "sample_xlsx", glob.glob(os.path.join(os.path.dirname(__file__), "data", "*.xlsx"))
 )
 def test_audit_excel_table_output(sample_xlsx):
     runner = CliRunner()
@@ -28,6 +29,7 @@ def test_audit_excel_table_output(sample_xlsx):
         parts = re.split(r"\s{2,}", line.strip())
         assert len(parts) >= 4, f"Bad line in audit table: {line}"
 
+
 def test_audit_excel_json_output(tmp_path):
     # pick any test workbook
     sample = glob.glob(os.path.join(os.path.dirname(__file__), "data", "*.xlsx"))[0]
@@ -37,9 +39,10 @@ def test_audit_excel_json_output(tmp_path):
 
     # JSON must parse to a list of dicts
     import json
+
     payload = json.loads(result.output)
     assert isinstance(payload, list)
     assert all(isinstance(obj, dict) for obj in payload)
     # check expected keys
     for obj in payload:
-        assert {"step","sheet","level","message"}.issubset(obj.keys())
+        assert {"step", "sheet", "level", "message"}.issubset(obj.keys())

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,35 @@
+import pytest
+import pandas as pd
+from P6.__main__ import preprocess
+from P6.loader import load_sheets_as_tables
+
+@pytest.fixture
+def simple_workbook(tmp_path):
+    # build a tiny Excel with one sheet and minimal columns
+    df = pd.DataFrame({
+        "contact_email": ["a@b.com"],
+        "phasing": [True],
+        "chromosome": ["chr1"],
+        "start_position": [100],
+        "end_position": [100],
+        "reference": ["A"],
+        "alternate": ["T"],
+        "gene_symbol": ["GENE"],
+        "hgvsg": ["g.100A>T"],
+        "hgvsc": [""],
+        "hgvsp": [""],
+        "zygosity": ["het"],
+        "inheritance": ["unknown"],
+    }, index=["PAT1"])
+    path = tmp_path / "wb.xlsx"
+    with pd.ExcelWriter(path, engine="openpyxl") as w:
+        df.to_excel(w, sheet_name="geno")
+    return str(path)
+
+def test_preprocess_detects_variant_sheet(simple_workbook):
+    tables = load_sheets_as_tables(simple_workbook)
+    entries = preprocess(tables)
+    # we expect at least one classify-sheet entry
+    assert any(e.step == "classify-sheet" and e.sheet == "geno" for e in entries)
+    # and no variant-check errors since this is valid
+    assert not any(e.step == "variant-check" and e.level == "error" for e in entries)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -3,28 +3,33 @@ import pandas as pd
 from P6.__main__ import preprocess
 from P6.loader import load_sheets_as_tables
 
+
 @pytest.fixture
 def simple_workbook(tmp_path):
     # build a tiny Excel with one sheet and minimal columns
-    df = pd.DataFrame({
-        "contact_email": ["a@b.com"],
-        "phasing": [True],
-        "chromosome": ["chr1"],
-        "start_position": [100],
-        "end_position": [100],
-        "reference": ["A"],
-        "alternate": ["T"],
-        "gene_symbol": ["GENE"],
-        "hgvsg": ["g.100A>T"],
-        "hgvsc": [""],
-        "hgvsp": [""],
-        "zygosity": ["het"],
-        "inheritance": ["unknown"],
-    }, index=["PAT1"])
+    df = pd.DataFrame(
+        {
+            "contact_email": ["a@b.com"],
+            "phasing": [True],
+            "chromosome": ["chr1"],
+            "start_position": [100],
+            "end_position": [100],
+            "reference": ["A"],
+            "alternate": ["T"],
+            "gene_symbol": ["GENE"],
+            "hgvsg": ["g.100A>T"],
+            "hgvsc": [""],
+            "hgvsp": [""],
+            "zygosity": ["het"],
+            "inheritance": ["unknown"],
+        },
+        index=["PAT1"],
+    )
     path = tmp_path / "wb.xlsx"
     with pd.ExcelWriter(path, engine="openpyxl") as w:
         df.to_excel(w, sheet_name="geno")
     return str(path)
+
 
 def test_preprocess_detects_variant_sheet(simple_workbook):
     tables = load_sheets_as_tables(simple_workbook)


### PR DESCRIPTION
(cli): add audit-excel command and expand preprocessing tests
- **New CLI command** `audit-excel` in `src/P6/__main__.py`
  - Options:
    - `-e, --excel-path <FILE>` (required) to specify the workbook
    - `-r, --report-json` flag to toggle JSON output
  - Reads sheets via existing `_read_sheets()`
  - Calls `preprocess()` to collect audit entries
  - Renders either:
    - Human-readable table (columns: SHEET, STEP, LEVEL, MESSAGE; two spaces between columns for reliable parsing)
    - JSON array of `{ step, sheet, level, message }` objects with `--report-json`
- **Tests for `audit-excel`** in `tests/test_cli_audit_excel.py`
- **Unit tests for `preprocess()`** in `tests/test_preprocess.py`